### PR TITLE
Step tests refactor

### DIFF
--- a/tests/ui/step/StepTest.cpp
+++ b/tests/ui/step/StepTest.cpp
@@ -3,13 +3,9 @@
 #include "ui/step/Step.h"
 #include "ui/view/ViewMock.h"
 #include "ui/FactoryMock.h"
-#include "ui/ContextMock.h"
-#include "utilities/CreateProtoObjects.h"
 #include "logging/Initialisation.h"
 
 using ::testing::Return;
-using ::testing::AtLeast;
-using ::testing::InSequence;
 using ::testing::_;
 
 using namespace ui;
@@ -20,348 +16,274 @@ public:
     void SetUp() override {
         ConsoleLogging{boost::log::trivial::fatal};
 
-        task_ = std::make_shared<Task>();
-        id_ = std::make_shared<TaskId>();
-        task_with_id_ = std::make_shared<TaskWithId>();
-        many_simple_tasks_ = std::make_shared<ManyTasksWithId>();
-        composite_task_ = std::make_shared<CompositeTask>();
-        many_composite_tasks_ = std::make_shared<ManyCompositeTasks>();
-
-        auto reader = std::make_shared<Reader>();
-        auto printer = std::make_shared<Printer>();
-        view_ = std::make_shared<ViewMock>(reader, printer);
-        factory_ = std::make_shared<Factory>(view_);
-        auto Result = std::make_shared<command::Result>(false);
-        context_ = std::make_shared<ContextMock>(Result);
+        view_ = std::make_shared<ViewMock>(std::make_shared<Reader>(), std::make_shared<Printer>());
+        factory_ = std::make_shared<FactoryMock>(view_);
     }
 
 protected:
-    std::shared_ptr<Task> task_;
-    std::shared_ptr<TaskId> id_;
-    std::shared_ptr<TaskWithId> task_with_id_;
-    std::shared_ptr<ManyTasksWithId> many_simple_tasks_;
-    std::shared_ptr<CompositeTask> composite_task_;
-    std::shared_ptr<ManyCompositeTasks> many_composite_tasks_;
-
     std::shared_ptr<ViewMock> view_;
-    std::shared_ptr<Factory> factory_;
-    std::shared_ptr<ContextMock> context_;
+    std::shared_ptr<FactoryMock> factory_;
 };
 
 TEST_F(StepTest, shouldReadNextStep) {
     auto step = Root(factory_, view_);
+    auto context = Context(std::make_shared<command::Result>(false));
 
-    EXPECT_CALL(*view_, ReadCommand())
-            .Times(1)
-            .WillOnce(Return(Type::QUIT));
-    EXPECT_CALL(*context_, result())
-            .Times(1)
-            .WillOnce(Return(std::make_shared<command::Result>(false)));
-    EXPECT_TRUE(std::dynamic_pointer_cast<Quit>(
-            step.execute(*context_)));
+    EXPECT_CALL(*view_, ReadCommand()).WillOnce(Return(Type::QUIT));
+    EXPECT_CALL(*factory_, CreateStep(Type::QUIT)).Times(1);
+
+    step.execute(context);
 }
 
 TEST_F(StepTest, shouldPrintResultIfNessesary) {
     auto step = Root(factory_, view_);
+    auto context = Context(std::make_shared<command::Result>(command::Error::CANNOT_LOAD_FROM_FILE));
 
-    EXPECT_CALL(*context_, result())
-            .Times(1)
-            .WillOnce(Return(std::make_shared<command::Result>(command::Error::CANNOT_LOAD_FROM_FILE)));
-    EXPECT_TRUE(std::dynamic_pointer_cast<Print>(
-            step.execute(*context_)));
+    EXPECT_CALL(*factory_, CreateStep(Type::PRINT)).Times(1);
+
+    step.execute(context);
 }
 
 TEST_F(StepTest, shouldQuit) {
     auto step = Quit(factory_, view_);
-    EXPECT_CALL(*view_, PrintQuit())
-            .Times(1);
-    EXPECT_CALL(*context_, set_command(_))
-            .Times(1);
-    EXPECT_TRUE(std::dynamic_pointer_cast<Root>(
-            step.execute(*context_)));
+    auto context = Context("");
+
+    EXPECT_CALL(*view_, PrintQuit()).Times(1);
+    EXPECT_CALL(*factory_, GetInitialStep()).Times(1);
+
+    step.execute(context);
+    EXPECT_TRUE(std::dynamic_pointer_cast<command::Quit>(context.command()));
 }
 
 TEST_F(StepTest, shouldHelp) {
     auto step = Help(factory_, view_);
-    EXPECT_CALL(*view_, PrintHelp())
-            .Times(1);
-    EXPECT_TRUE(std::dynamic_pointer_cast<Root>(
-            step.execute(*context_)));
+    auto context = Context("");
+
+    EXPECT_CALL(*view_, PrintHelp()).Times(1);
+    EXPECT_CALL(*factory_, GetInitialStep()).Times(1);
+
+    step.execute(context);
 }
 
 TEST_F(StepTest, shouldPrintError) {
     auto step = Print(factory_, view_);
-    EXPECT_CALL(*context_, result())
-            .Times(5)
-            .WillRepeatedly(Return(std::make_shared<command::Result>(command::Error::INCORRECT_PARENT_ID)));
-    EXPECT_CALL(*view_, PrintError(_))
-            .Times(1);
-    EXPECT_CALL(*context_, set_result())
-            .Times(1);
-    EXPECT_TRUE(std::dynamic_pointer_cast<Root>(
-            step.execute(*context_)));
+    auto context = Context(std::make_shared<command::Result>(command::Error::INCORRECT_PARENT_ID));
+
+    EXPECT_CALL(*view_, PrintError(command::Error::INCORRECT_PARENT_ID)).Times(1);
+    EXPECT_CALL(*factory_, GetInitialStep()).Times(1);
+
+    step.execute(context);
+    EXPECT_FALSE(context.result()->has_value());
 }
 
 TEST_F(StepTest, shouldPrintCompositeTask) {
     auto step = Print(factory_, view_);
+    auto context = Context(std::make_shared<command::Result>(CompositeTask()));
 
-    EXPECT_CALL(*context_, result())
-            .Times(5)
-            .WillRepeatedly(Return(std::make_shared<command::Result>(*composite_task_)));
-    EXPECT_CALL(*view_, PrintCompositeTask(_))
-            .Times(1);
-    EXPECT_CALL(*context_, set_result())
-            .Times(1);
-    EXPECT_TRUE(std::dynamic_pointer_cast<Root>(
-            step.execute(*context_)));
+    EXPECT_CALL(*view_, PrintCompositeTask(_)).Times(1);
+    EXPECT_CALL(*factory_, GetInitialStep()).Times(1);
+
+    step.execute(context);
+    EXPECT_FALSE(context.result()->has_value());
 }
 
 TEST_F(StepTest, shouldPrintManyTasks) {
     auto step = Print(factory_, view_);
+    auto context = Context(std::make_shared<command::Result>(ManyTasksWithId()));
 
-    EXPECT_CALL(*context_, result())
-            .Times(5)
-            .WillRepeatedly(Return(std::make_shared<command::Result>(*many_simple_tasks_)));
-    EXPECT_CALL(*view_, PrintManyTasksWithId(_))
-            .Times(1);
-    EXPECT_CALL(*context_, set_result())
-            .Times(1);
-    EXPECT_TRUE(std::dynamic_pointer_cast<Root>(
-            step.execute(*context_)));
+    EXPECT_CALL(*view_, PrintManyTasksWithId(_)).Times(1);
+    EXPECT_CALL(*factory_, GetInitialStep()).Times(1);
+
+    step.execute(context);
+    EXPECT_FALSE(context.result()->has_value());
 }
 
 TEST_F(StepTest, shouldPrintManyCompositeTasks) {
     auto step = Print(factory_, view_);
+    auto context = Context(std::make_shared<command::Result>(ManyCompositeTasks()));
 
-    EXPECT_CALL(*context_, result())
-            .Times(5)
-            .WillRepeatedly(Return(std::make_shared<command::Result>(*many_composite_tasks_)));
-    EXPECT_CALL(*view_, PrintManyCompositeTasks(_))
-            .Times(1);
-    EXPECT_CALL(*context_, set_result())
-            .Times(1);
-    EXPECT_TRUE(std::dynamic_pointer_cast<Root>(
-            step.execute(*context_)));
+    EXPECT_CALL(*view_, PrintManyCompositeTasks(_)).Times(1);
+    EXPECT_CALL(*factory_, GetInitialStep()).Times(1);
+
+    step.execute(context);
+    EXPECT_FALSE(context.result()->has_value());
 }
 
 TEST_F(StepTest, shouldCreateCommandComplete) {
     auto step = Complete(factory_, view_);
-    EXPECT_CALL(*view_, ReadId(_))
-            .Times(1)
-            .WillOnce(Return(CreateTaskId(0)));
-    EXPECT_CALL(*view_, Confirm())
-            .Times(1)
-            .WillOnce(Return(true));
-    EXPECT_CALL(*context_, set_command(_))
-            .Times(1);
-    EXPECT_TRUE(std::dynamic_pointer_cast<Root>(
-            step.execute(*context_)));
+    auto context = Context("");
+
+    EXPECT_CALL(*view_, ReadId("[Complete Task]")).WillOnce(Return(TaskId()));
+    EXPECT_CALL(*view_, Confirm()).WillOnce(Return(true));
+    EXPECT_CALL(*factory_, GetInitialStep()).Times(1);
+
+    step.execute(context);
+    EXPECT_TRUE(std::dynamic_pointer_cast<command::Complete>(context.command()));
 }
 
 TEST_F(StepTest, shouldWorkIfNotConfirmComplete) {
     auto step = Complete(factory_, view_);
+    auto context = Context("");
 
-    EXPECT_CALL(*view_, ReadId(_))
-            .Times(1)
-            .WillOnce(Return(CreateTaskId(0)));
-    EXPECT_CALL(*view_, Confirm())
-            .Times(1)
-            .WillOnce(Return(false));
-    EXPECT_TRUE(std::dynamic_pointer_cast<Root>(
-            step.execute(*context_)));
+    EXPECT_CALL(*view_, ReadId("[Complete Task]")).WillOnce(Return(TaskId()));
+    EXPECT_CALL(*view_, Confirm()).WillOnce(Return(false));
+    EXPECT_CALL(*factory_, GetInitialStep()).Times(1);
+
+    step.execute(context);
+    EXPECT_EQ(context.command(), nullptr);
 }
 
 TEST_F(StepTest, shouldCreateCommandDelete) {
     auto step = Delete(factory_, view_);
+    auto context = Context("");
 
-    EXPECT_CALL(*view_, ReadId(_))
-            .Times(1)
-            .WillOnce(Return(CreateTaskId(0)));
-    EXPECT_CALL(*view_, Confirm())
-            .Times(1)
-            .WillOnce(Return(true));
-    EXPECT_CALL(*context_, set_command(_))
-            .Times(1);
-    EXPECT_TRUE(std::dynamic_pointer_cast<Root>(
-            step.execute(*context_)));
+    EXPECT_CALL(*view_, ReadId("[Delete Task]")).WillOnce(Return(TaskId()));
+    EXPECT_CALL(*view_, Confirm()).WillOnce(Return(true));
+    EXPECT_CALL(*factory_, GetInitialStep()).Times(1);
+
+    step.execute(context);
+    EXPECT_TRUE(std::dynamic_pointer_cast<command::Delete>(context.command()));
 }
 
 TEST_F(StepTest, shouldWorkIfNotConfirmDelete) {
     auto step = Delete(factory_, view_);
+    auto context = Context("");
 
-    EXPECT_CALL(*view_, ReadId(_))
-            .Times(1)
-            .WillOnce(Return(CreateTaskId(0)));
-    EXPECT_CALL(*view_, Confirm())
-            .Times(1)
-            .WillOnce(Return(false));
-    EXPECT_TRUE(std::dynamic_pointer_cast<Root>(
-            step.execute(*context_)));
+    EXPECT_CALL(*view_, ReadId("[Delete Task]")).WillOnce(Return(TaskId()));
+    EXPECT_CALL(*view_, Confirm()).WillOnce(Return(false));
+    EXPECT_CALL(*factory_, GetInitialStep()).Times(1);
+
+    step.execute(context);
+    EXPECT_EQ(context.command(), nullptr);
 }
 
 TEST_F(StepTest, shouldCreateCommandSave) {
     auto step = Save(factory_, view_);
+    auto context = Context("");
 
-    EXPECT_CALL(*view_, ReadFilename(_))
-            .Times(1)
-            .WillOnce(Return(""));
-    EXPECT_CALL(*view_, Confirm())
-            .Times(1)
-            .WillOnce(Return(true));
-    EXPECT_CALL(*context_, set_command(_))
-            .Times(1);
-    EXPECT_TRUE(std::dynamic_pointer_cast<Root>(
-            step.execute(*context_)));
+    EXPECT_CALL(*view_, ReadFilename("[Save to file]")).WillOnce(Return(""));
+    EXPECT_CALL(*view_, Confirm()).WillOnce(Return(true));
+    EXPECT_CALL(*factory_, GetInitialStep()).Times(1);
+
+    step.execute(context);
+    EXPECT_TRUE(std::dynamic_pointer_cast<command::Save>(context.command()));
 }
 
 TEST_F(StepTest, shouldWorkIfNotConfirmSave) {
     auto step = Save(factory_, view_);
+    auto context = Context("");
 
-    EXPECT_CALL(*view_, ReadFilename(_))
-            .Times(1)
-            .WillOnce(Return(""));
-    EXPECT_CALL(*view_, Confirm())
-            .Times(1)
-            .WillOnce(Return(false));
-    EXPECT_TRUE(std::dynamic_pointer_cast<Root>(
-            step.execute(*context_)));
+    EXPECT_CALL(*view_, ReadFilename("[Save to file]")).WillOnce(Return(""));
+    EXPECT_CALL(*view_, Confirm()).WillOnce(Return(false));
+    EXPECT_CALL(*factory_, GetInitialStep()).Times(1);
+
+    step.execute(context);
+    EXPECT_EQ(context.command(), nullptr);
 }
 
 TEST_F(StepTest, shouldCreateCommandLoad) {
     auto step = Load(factory_, view_);
+    auto context = Context("");
 
-    EXPECT_CALL(*view_, ReadFilename(_))
-            .Times(1)
-            .WillOnce(Return(""));
-    EXPECT_CALL(*view_, Confirm())
-            .Times(1)
-            .WillOnce(Return(true));
-    EXPECT_CALL(*context_, set_command(_))
-            .Times(1);
-    EXPECT_TRUE(std::dynamic_pointer_cast<Root>(
-            step.execute(*context_)));
+    EXPECT_CALL(*view_, ReadFilename("[Load from file]")).WillOnce(Return(""));
+    EXPECT_CALL(*view_, Confirm()).WillOnce(Return(true));
+    EXPECT_CALL(*factory_, GetInitialStep()).Times(1);
+
+    step.execute(context);
+    EXPECT_TRUE(std::dynamic_pointer_cast<command::Load>(context.command()));
 }
 
 TEST_F(StepTest, shouldWorkIfNotConfirmLoad) {
     auto step = Load(factory_, view_);
+    auto context = Context("");
 
-    EXPECT_CALL(*view_, ReadFilename(_))
-            .Times(1)
-            .WillOnce(Return(""));
-    EXPECT_CALL(*view_, Confirm())
-            .Times(1)
-            .WillOnce(Return(false));
-    EXPECT_TRUE(std::dynamic_pointer_cast<Root>(
-            step.execute(*context_)));
+    EXPECT_CALL(*view_, ReadFilename("[Load from file]")).WillOnce(Return(""));
+    EXPECT_CALL(*view_, Confirm()).WillOnce(Return(false));
+    EXPECT_CALL(*factory_, GetInitialStep()).Times(1);
+
+    step.execute(context);
+    EXPECT_EQ(context.command(), nullptr);
 }
 
 TEST_F(StepTest, shouldCreateCommandShow) {
     auto step = Show(factory_, view_);
+    auto context = Context("");
 
-    EXPECT_CALL(*view_, ReadIfPrintSubtasks(_))
-            .Times(1);
-    EXPECT_CALL(*view_, ReadSortBy(_))
-            .Times(1);
-    EXPECT_CALL(*context_, set_command(_))
-            .Times(1);
-    EXPECT_TRUE(std::dynamic_pointer_cast<Root>(
-            step.execute(*context_)));
+    EXPECT_CALL(*view_, ReadIfPrintSubtasks("[Show]")).Times(1);
+    EXPECT_CALL(*view_, ReadSortBy("[Show]")).Times(1);
+    EXPECT_CALL(*factory_, GetInitialStep()).Times(1);
+
+    step.execute(context);
+    EXPECT_TRUE(std::dynamic_pointer_cast<command::Show>(context.command()));
 }
 
 TEST_F(StepTest, shouldCreateCommandShowTask) {
     auto step = ShowTask(factory_, view_);
+    auto context = Context("");
 
-    EXPECT_CALL(*view_, ReadId(_))
-            .Times(1);
-    EXPECT_CALL(*view_, ReadSortBy(_))
-            .Times(1);
-    EXPECT_CALL(*context_, set_command(_))
-            .Times(1);
-    EXPECT_TRUE(std::dynamic_pointer_cast<Root>(
-            step.execute(*context_)));
+    EXPECT_CALL(*view_, ReadId("[Show Task]")).Times(1);
+    EXPECT_CALL(*view_, ReadSortBy("[Show Task]")).Times(1);
+    EXPECT_CALL(*factory_, GetInitialStep()).Times(1);
+
+    step.execute(context);
+    EXPECT_TRUE(std::dynamic_pointer_cast<command::ShowTask>(context.command()));
 }
 
 TEST_F(StepTest, shouldCreateCommandShowLabel) {
     auto step = ShowByLabel(factory_, view_);
+    auto context = Context("");
 
-    EXPECT_CALL(*view_, ReadLabel(_))
-            .Times(1);
-    EXPECT_CALL(*view_, ReadSortBy(_))
-            .Times(1);
-    EXPECT_CALL(*context_, set_command(_))
-            .Times(1);
-    EXPECT_TRUE(std::dynamic_pointer_cast<Root>(
-            step.execute(*context_)));
+    EXPECT_CALL(*view_, ReadLabel("[Show by label]")).Times(1);
+    EXPECT_CALL(*view_, ReadSortBy("[Show by label]")).Times(1);
+    EXPECT_CALL(*factory_, GetInitialStep()).Times(1);
+
+    step.execute(context);
+    EXPECT_TRUE(std::dynamic_pointer_cast<command::ShowByLabel>(context.command()));
 }
 
 TEST_F(StepTest, shouldAddTask) {
-    auto factory = std::make_shared<FactoryMock>(view_);
-    auto step = Add(factory, view_);
+    auto step = Add(factory_, view_);
+    auto context = Context("");
 
-    EXPECT_CALL(*factory, GetInitialSubStep())
-            .Times(1)
-            .WillOnce(Return(std::make_shared<SubStepLabel>(factory_, view_)));
+    EXPECT_CALL(*factory_, GetInitialSubStep())
+            .WillOnce(Return(std::make_shared<SubStepLabel>(std::make_shared<Factory>(view_), view_)));
 
-    EXPECT_CALL(*view_, ReadLabels(_))
-            .Times(1)
-            .WillOnce(Return(std::vector<std::string>{"label"}));
-    EXPECT_CALL(*view_, Confirm())
-            .Times(1)
-            .WillOnce(Return(true));
-    EXPECT_CALL(*context_, set_command(_))
-            .Times(1);
-    EXPECT_CALL(*factory, GetInitialStep())
-            .Times(1);
+    EXPECT_CALL(*view_, ReadLabels("[Add Task]")).WillOnce(Return(std::vector<std::string>{"label"}));
+    EXPECT_CALL(*view_, Confirm()).WillOnce(Return(true));
+    EXPECT_CALL(*factory_, GetInitialStep()).Times(1);
 
-    step.execute(*context_);
+    step.execute(context);
+    EXPECT_TRUE(std::dynamic_pointer_cast<command::Add>(context.command()));
 }
 
 TEST_F(StepTest, shouldAddSubTask) {
-    auto factory = std::make_shared<FactoryMock>(view_);
-    auto step = AddSub(factory, view_);
+    auto step = AddSub(factory_, view_);
+    auto context = Context("");
 
-    EXPECT_CALL(*view_, ReadParentId(_))
-            .Times(1)
-            .WillOnce(Return(CreateTaskId(0)));
-    EXPECT_CALL(*factory, GetInitialSubStep())
-            .Times(1)
-            .WillOnce(Return(std::make_shared<SubStepLabel>(factory_, view_)));
+    EXPECT_CALL(*view_, ReadParentId("[Add SubTask]")).WillOnce(Return(TaskId()));
+    EXPECT_CALL(*factory_, GetInitialSubStep())
+            .WillOnce(Return(std::make_shared<SubStepLabel>(std::make_shared<Factory>(view_), view_)));
 
-    EXPECT_CALL(*view_, ReadLabels(_))
-            .Times(1)
-            .WillOnce(Return(std::vector<std::string>{"label"}));
-    EXPECT_CALL(*view_, Confirm())
-            .Times(1)
-            .WillOnce(Return(true));
-    EXPECT_CALL(*context_, set_command(_))
-            .Times(1);
-    EXPECT_CALL(*factory, GetInitialStep())
-            .Times(1);
+    EXPECT_CALL(*view_, ReadLabels("[Add SubTask]")).WillOnce(Return(std::vector<std::string>{"label"}));
+    EXPECT_CALL(*view_, Confirm()).WillOnce(Return(true));
+    EXPECT_CALL(*factory_, GetInitialStep()).Times(1);
 
-    step.execute(*context_);
+    step.execute(context);
+    EXPECT_TRUE(std::dynamic_pointer_cast<command::AddSub>(context.command()));
 }
 
 TEST_F(StepTest, shouldEditTask) {
-    auto factory = std::make_shared<FactoryMock>(view_);
-    auto step = Edit(factory, view_);
+    auto step = Edit(factory_, view_);
+    auto context = Context("");
 
-    EXPECT_CALL(*view_, ReadId(_))
-            .Times(1)
-            .WillOnce(Return(CreateTaskId(0)));
-    EXPECT_CALL(*factory, GetInitialSubStep())
-            .Times(1)
-            .WillOnce(Return(std::make_shared<SubStepLabel>(factory_, view_)));
+    EXPECT_CALL(*view_, ReadId("[Edit Task]")).WillOnce(Return(TaskId()));
+    EXPECT_CALL(*factory_, GetInitialSubStep())
+            .WillOnce(Return(std::make_shared<SubStepLabel>(std::make_shared<Factory>(view_), view_)));
 
-    EXPECT_CALL(*view_, ReadLabels(_))
-            .Times(1)
-            .WillOnce(Return(std::vector<std::string>{"label"}));
-    EXPECT_CALL(*view_, Confirm())
-            .Times(1)
-            .WillOnce(Return(true));
-    EXPECT_CALL(*context_, set_command(_))
-            .Times(1);
-    EXPECT_CALL(*factory, GetInitialStep())
-            .Times(1);
+    EXPECT_CALL(*view_, ReadLabels("[Edit Task]")).WillOnce(Return(std::vector<std::string>{"label"}));
+    EXPECT_CALL(*view_, Confirm()).WillOnce(Return(true));
+    EXPECT_CALL(*factory_, GetInitialStep()).Times(1);
 
-    step.execute(*context_);
+    step.execute(context);
+    EXPECT_TRUE(std::dynamic_pointer_cast<command::Edit>(context.command()));
 }

--- a/tests/ui/step/StepTest.cpp
+++ b/tests/ui/step/StepTest.cpp
@@ -1,8 +1,8 @@
 #include "gtest/gtest.h"
 #include "gmock/gmock.h"
 #include "ui/step/Step.h"
-#include "ui/view/ViewMock.h"
 #include "ui/FactoryMock.h"
+#include "ui/view/ViewMock.h"
 #include "logging/Initialisation.h"
 
 using ::testing::Return;
@@ -26,8 +26,8 @@ protected:
 };
 
 TEST_F(StepTest, shouldReadNextStep) {
-    auto step = Root(factory_, view_);
-    auto context = Context(std::make_shared<command::Result>(false));
+    Root step{factory_, view_};
+    Context context(std::make_shared<command::Result>(false));
 
     EXPECT_CALL(*view_, ReadCommand()).WillOnce(Return(Type::QUIT));
     EXPECT_CALL(*factory_, CreateStep(Type::QUIT)).Times(1);
@@ -36,8 +36,8 @@ TEST_F(StepTest, shouldReadNextStep) {
 }
 
 TEST_F(StepTest, shouldPrintResultIfNessesary) {
-    auto step = Root(factory_, view_);
-    auto context = Context(std::make_shared<command::Result>(command::Error::CANNOT_LOAD_FROM_FILE));
+    Root step{factory_, view_};
+    Context context{std::make_shared<command::Result>(command::Error::CANNOT_LOAD_FROM_FILE)};
 
     EXPECT_CALL(*factory_, CreateStep(Type::PRINT)).Times(1);
 
@@ -45,8 +45,8 @@ TEST_F(StepTest, shouldPrintResultIfNessesary) {
 }
 
 TEST_F(StepTest, shouldQuit) {
-    auto step = Quit(factory_, view_);
-    auto context = Context("");
+    Quit step{factory_, view_};
+    Context context{""};
 
     EXPECT_CALL(*view_, PrintQuit()).Times(1);
     EXPECT_CALL(*factory_, GetInitialStep()).Times(1);
@@ -56,8 +56,8 @@ TEST_F(StepTest, shouldQuit) {
 }
 
 TEST_F(StepTest, shouldHelp) {
-    auto step = Help(factory_, view_);
-    auto context = Context("");
+    Help step{factory_, view_};
+    Context context{""};
 
     EXPECT_CALL(*view_, PrintHelp()).Times(1);
     EXPECT_CALL(*factory_, GetInitialStep()).Times(1);
@@ -66,8 +66,8 @@ TEST_F(StepTest, shouldHelp) {
 }
 
 TEST_F(StepTest, shouldPrintError) {
-    auto step = Print(factory_, view_);
-    auto context = Context(std::make_shared<command::Result>(command::Error::INCORRECT_PARENT_ID));
+    Print step{factory_, view_};
+    Context context{std::make_shared<command::Result>(command::Error::INCORRECT_PARENT_ID)};
 
     EXPECT_CALL(*view_, PrintError(command::Error::INCORRECT_PARENT_ID)).Times(1);
     EXPECT_CALL(*factory_, GetInitialStep()).Times(1);
@@ -77,8 +77,8 @@ TEST_F(StepTest, shouldPrintError) {
 }
 
 TEST_F(StepTest, shouldPrintCompositeTask) {
-    auto step = Print(factory_, view_);
-    auto context = Context(std::make_shared<command::Result>(CompositeTask()));
+    Print step{factory_, view_};
+    Context context{std::make_shared<command::Result>(CompositeTask())};
 
     EXPECT_CALL(*view_, PrintCompositeTask(_)).Times(1);
     EXPECT_CALL(*factory_, GetInitialStep()).Times(1);
@@ -88,8 +88,8 @@ TEST_F(StepTest, shouldPrintCompositeTask) {
 }
 
 TEST_F(StepTest, shouldPrintManyTasks) {
-    auto step = Print(factory_, view_);
-    auto context = Context(std::make_shared<command::Result>(ManyTasksWithId()));
+    Print step{factory_, view_};
+    Context context{std::make_shared<command::Result>(ManyTasksWithId())};
 
     EXPECT_CALL(*view_, PrintManyTasksWithId(_)).Times(1);
     EXPECT_CALL(*factory_, GetInitialStep()).Times(1);
@@ -99,8 +99,8 @@ TEST_F(StepTest, shouldPrintManyTasks) {
 }
 
 TEST_F(StepTest, shouldPrintManyCompositeTasks) {
-    auto step = Print(factory_, view_);
-    auto context = Context(std::make_shared<command::Result>(ManyCompositeTasks()));
+    Print step{factory_, view_};
+    Context context{std::make_shared<command::Result>(ManyCompositeTasks())};
 
     EXPECT_CALL(*view_, PrintManyCompositeTasks(_)).Times(1);
     EXPECT_CALL(*factory_, GetInitialStep()).Times(1);
@@ -110,8 +110,8 @@ TEST_F(StepTest, shouldPrintManyCompositeTasks) {
 }
 
 TEST_F(StepTest, shouldCreateCommandComplete) {
-    auto step = Complete(factory_, view_);
-    auto context = Context("");
+    Complete step{factory_, view_};
+    Context context{""};
 
     EXPECT_CALL(*view_, ReadId("[Complete Task]")).WillOnce(Return(TaskId()));
     EXPECT_CALL(*view_, Confirm()).WillOnce(Return(true));
@@ -122,8 +122,8 @@ TEST_F(StepTest, shouldCreateCommandComplete) {
 }
 
 TEST_F(StepTest, shouldWorkIfNotConfirmComplete) {
-    auto step = Complete(factory_, view_);
-    auto context = Context("");
+    Complete step{factory_, view_};
+    Context context{""};
 
     EXPECT_CALL(*view_, ReadId("[Complete Task]")).WillOnce(Return(TaskId()));
     EXPECT_CALL(*view_, Confirm()).WillOnce(Return(false));
@@ -134,8 +134,8 @@ TEST_F(StepTest, shouldWorkIfNotConfirmComplete) {
 }
 
 TEST_F(StepTest, shouldCreateCommandDelete) {
-    auto step = Delete(factory_, view_);
-    auto context = Context("");
+    Delete step{factory_, view_};
+    Context context{""};
 
     EXPECT_CALL(*view_, ReadId("[Delete Task]")).WillOnce(Return(TaskId()));
     EXPECT_CALL(*view_, Confirm()).WillOnce(Return(true));
@@ -146,8 +146,8 @@ TEST_F(StepTest, shouldCreateCommandDelete) {
 }
 
 TEST_F(StepTest, shouldWorkIfNotConfirmDelete) {
-    auto step = Delete(factory_, view_);
-    auto context = Context("");
+    Delete step{factory_, view_};
+    Context context{""};
 
     EXPECT_CALL(*view_, ReadId("[Delete Task]")).WillOnce(Return(TaskId()));
     EXPECT_CALL(*view_, Confirm()).WillOnce(Return(false));
@@ -158,8 +158,8 @@ TEST_F(StepTest, shouldWorkIfNotConfirmDelete) {
 }
 
 TEST_F(StepTest, shouldCreateCommandSave) {
-    auto step = Save(factory_, view_);
-    auto context = Context("");
+    Save step{factory_, view_};
+    Context context{""};
 
     EXPECT_CALL(*view_, ReadFilename("[Save to file]")).WillOnce(Return(""));
     EXPECT_CALL(*view_, Confirm()).WillOnce(Return(true));
@@ -170,8 +170,8 @@ TEST_F(StepTest, shouldCreateCommandSave) {
 }
 
 TEST_F(StepTest, shouldWorkIfNotConfirmSave) {
-    auto step = Save(factory_, view_);
-    auto context = Context("");
+    Save step{factory_, view_};
+    Context context{""};
 
     EXPECT_CALL(*view_, ReadFilename("[Save to file]")).WillOnce(Return(""));
     EXPECT_CALL(*view_, Confirm()).WillOnce(Return(false));
@@ -182,8 +182,8 @@ TEST_F(StepTest, shouldWorkIfNotConfirmSave) {
 }
 
 TEST_F(StepTest, shouldCreateCommandLoad) {
-    auto step = Load(factory_, view_);
-    auto context = Context("");
+    Load step{factory_, view_};
+    Context context{""};
 
     EXPECT_CALL(*view_, ReadFilename("[Load from file]")).WillOnce(Return(""));
     EXPECT_CALL(*view_, Confirm()).WillOnce(Return(true));
@@ -194,8 +194,8 @@ TEST_F(StepTest, shouldCreateCommandLoad) {
 }
 
 TEST_F(StepTest, shouldWorkIfNotConfirmLoad) {
-    auto step = Load(factory_, view_);
-    auto context = Context("");
+    Load step{factory_, view_};
+    Context context{""};
 
     EXPECT_CALL(*view_, ReadFilename("[Load from file]")).WillOnce(Return(""));
     EXPECT_CALL(*view_, Confirm()).WillOnce(Return(false));
@@ -206,8 +206,8 @@ TEST_F(StepTest, shouldWorkIfNotConfirmLoad) {
 }
 
 TEST_F(StepTest, shouldCreateCommandShow) {
-    auto step = Show(factory_, view_);
-    auto context = Context("");
+    Show step{factory_, view_};
+    Context context{""};
 
     EXPECT_CALL(*view_, ReadIfPrintSubtasks("[Show]")).Times(1);
     EXPECT_CALL(*view_, ReadSortBy("[Show]")).Times(1);
@@ -218,8 +218,8 @@ TEST_F(StepTest, shouldCreateCommandShow) {
 }
 
 TEST_F(StepTest, shouldCreateCommandShowTask) {
-    auto step = ShowTask(factory_, view_);
-    auto context = Context("");
+    ShowTask step{factory_, view_};
+    Context context{""};
 
     EXPECT_CALL(*view_, ReadId("[Show Task]")).Times(1);
     EXPECT_CALL(*view_, ReadSortBy("[Show Task]")).Times(1);
@@ -229,9 +229,9 @@ TEST_F(StepTest, shouldCreateCommandShowTask) {
     EXPECT_TRUE(std::dynamic_pointer_cast<command::ShowTask>(context.command()));
 }
 
-TEST_F(StepTest, shouldCreateCommandShowLabel) {
-    auto step = ShowByLabel(factory_, view_);
-    auto context = Context("");
+TEST_F(StepTest, shouldCreateCommandShowByLabel) {
+    ShowByLabel step{factory_, view_};
+    Context context{""};
 
     EXPECT_CALL(*view_, ReadLabel("[Show by label]")).Times(1);
     EXPECT_CALL(*view_, ReadSortBy("[Show by label]")).Times(1);
@@ -242,8 +242,8 @@ TEST_F(StepTest, shouldCreateCommandShowLabel) {
 }
 
 TEST_F(StepTest, shouldAddTask) {
-    auto step = Add(factory_, view_);
-    auto context = Context("");
+    Add step{factory_, view_};
+    Context context{""};
 
     EXPECT_CALL(*factory_, GetInitialSubStep())
             .WillOnce(Return(std::make_shared<SubStepLabel>(std::make_shared<Factory>(view_), view_)));
@@ -257,8 +257,8 @@ TEST_F(StepTest, shouldAddTask) {
 }
 
 TEST_F(StepTest, shouldAddSubTask) {
-    auto step = AddSub(factory_, view_);
-    auto context = Context("");
+    AddSub step{factory_, view_};
+    Context context{""};
 
     EXPECT_CALL(*view_, ReadParentId("[Add SubTask]")).WillOnce(Return(TaskId()));
     EXPECT_CALL(*factory_, GetInitialSubStep())
@@ -273,8 +273,8 @@ TEST_F(StepTest, shouldAddSubTask) {
 }
 
 TEST_F(StepTest, shouldEditTask) {
-    auto step = Edit(factory_, view_);
-    auto context = Context("");
+    Edit step{factory_, view_};
+    Context context{""};
 
     EXPECT_CALL(*view_, ReadId("[Edit Task]")).WillOnce(Return(TaskId()));
     EXPECT_CALL(*factory_, GetInitialSubStep())

--- a/tests/ui/step/SubStepTest.cpp
+++ b/tests/ui/step/SubStepTest.cpp
@@ -1,7 +1,7 @@
 #include "gtest/gtest.h"
 #include "gmock/gmock.h"
 #include "ui/step/SubSteps.h"
-#include "ui/Factory.h"
+#include "ui/FactoryMock.h"
 #include "ui/view/ViewMock.h"
 
 using ::testing::Return;
@@ -13,12 +13,12 @@ class SubStepTest : public ::testing::Test {
 public:
     void SetUp() override {
         view_ = std::make_shared<ViewMock>(std::make_shared<Reader>(), std::make_shared<Printer>());
-        factory_ = std::make_shared<Factory>(view_);
+        factory_ = std::make_shared<FactoryMock>(view_);
     }
 
 protected:
     std::shared_ptr<ViewMock> view_;
-    std::shared_ptr<Factory> factory_;
+    std::shared_ptr<FactoryMock> factory_;
 };
 
 TEST_F(SubStepTest, shouldReadTitle) {
@@ -26,7 +26,8 @@ TEST_F(SubStepTest, shouldReadTitle) {
     Context context{"Add"};
 
     EXPECT_CALL(*view_, ReadTitle("Add")).WillOnce(Return("title"));
-    EXPECT_TRUE(std::dynamic_pointer_cast<SubStepPriority>(step.execute(context)));
+    EXPECT_CALL(*factory_, GetNextSubStepFrom(testing::An<const SubStepTitle&>())).Times(1);
+    step.execute(context);
 
     EXPECT_EQ(context.task()->title(), "title");
     EXPECT_FALSE(context.if_finished());
@@ -37,7 +38,8 @@ TEST_F(SubStepTest, shouldReadPriority) {
     Context context{"Edit"};
 
     EXPECT_CALL(*view_, ReadPriority("Edit")).WillOnce(Return(Task_Priority_LOW));
-    EXPECT_TRUE(std::dynamic_pointer_cast<SubStepDate>(step.execute(context)));
+    EXPECT_CALL(*factory_, GetNextSubStepFrom(testing::An<const SubStepPriority&>())).Times(1);
+    step.execute(context);
 
     EXPECT_EQ(context.task()->priority(), Task_Priority_LOW);
     EXPECT_FALSE(context.if_finished());
@@ -51,7 +53,8 @@ TEST_F(SubStepTest, shouldReadDate) {
     date.set_seconds(100);
 
     EXPECT_CALL(*view_, ReadDate("Add")).WillOnce(Return(date));
-    EXPECT_TRUE(std::dynamic_pointer_cast<SubStepLabel>(step.execute(context)));
+    EXPECT_CALL(*factory_, GetNextSubStepFrom(testing::An<const SubStepDate&>())).Times(1);
+    step.execute(context);
 
     ASSERT_TRUE(context.task()->has_date());
     EXPECT_EQ(context.task()->date().seconds(), 100);
@@ -64,7 +67,8 @@ TEST_F(SubStepTest, shouldReadLabels) {
 
     EXPECT_CALL(*view_, ReadLabels("Edit"))
             .WillOnce(Return(std::vector<std::string>{"label_1", "label_2"}));
-    EXPECT_TRUE(std::dynamic_pointer_cast<SubStepLabel>(step.execute(context)));
+    EXPECT_CALL(*factory_, GetNextSubStepFrom(testing::An<const SubStepLabel&>())).Times(1);
+    step.execute(context);
 
     ASSERT_EQ(context.task()->labels().size(), 2);
     EXPECT_EQ(context.task()->labels()[0], "label_1");

--- a/tests/ui/step/SubStepTest.cpp
+++ b/tests/ui/step/SubStepTest.cpp
@@ -1,14 +1,11 @@
 #include "gtest/gtest.h"
 #include "gmock/gmock.h"
 #include "ui/step/SubSteps.h"
+#include "ui/Factory.h"
 #include "ui/view/ViewMock.h"
-#include "ui/FactoryMock.h"
 #include "ui/ContextMock.h"
 
 using ::testing::Return;
-using ::testing::AtLeast;
-using ::testing::InSequence;
-using ::testing::_;
 
 using namespace ui;
 using namespace ui::step;
@@ -17,12 +14,9 @@ class SubStepTest : public ::testing::Test {
 public:
     void SetUp() override {
         task_ = std::make_shared<Task>();
-        auto reader = std::make_shared<Reader>();
-        auto printer = std::make_shared<Printer>();
-        view_ = std::make_shared<ViewMock>(reader, printer);
+        view_ = std::make_shared<ViewMock>(std::make_shared<Reader>(), std::make_shared<Printer>());
         factory_ = std::make_shared<Factory>(view_);
-        auto Result = std::make_shared<command::Result>(false);
-        context_ = std::make_shared<ContextMock>(Result);
+        context_ = std::make_shared<ContextMock>("");
     }
 
 protected:

--- a/tests/ui/step/SubStepTest.cpp
+++ b/tests/ui/step/SubStepTest.cpp
@@ -65,33 +65,31 @@ TEST_F(SubStepTest, shouldReadPriority) {
 TEST_F(SubStepTest, shouldReadDate) {
     auto step = SubStepDate(factory_, view_);
 
-    EXPECT_CALL(*view_, ReadDate(_))
-            .Times(1)
-            .WillOnce(Return(google::protobuf::Timestamp()));
-    EXPECT_CALL(*context_, wizard_string())
-            .Times(1);
-    EXPECT_CALL(*context_, task())
-            .Times(1)
-            .WillOnce(Return(task_));
-    EXPECT_TRUE(std::dynamic_pointer_cast<SubStepLabel>(
-            step.execute(*context_)));
+    EXPECT_CALL(*context_, wizard_string()).WillOnce(Return("Edit"));
+
+    google::protobuf::Timestamp date;
+    date.set_seconds(100);
+
+    EXPECT_CALL(*view_, ReadDate("Edit")).WillOnce(Return(date));
+    EXPECT_CALL(*context_, task()).WillOnce(Return(task_));
+
+    EXPECT_TRUE(std::dynamic_pointer_cast<SubStepLabel>(step.execute(*context_)));
 }
 
 TEST_F(SubStepTest, shouldReadLabels) {
     auto step = SubStepLabel(factory_, view_);
 
+    EXPECT_CALL(*context_, wizard_string()).WillOnce(Return("Add"));
     EXPECT_CALL(*view_, ReadLabels("Add"))
-            .Times(1)
             .WillOnce(Return(std::vector<std::string>{"label_1", "label_2"}));
-    EXPECT_CALL(*context_, wizard_string())
-            .Times(1)
-            .WillOnce(Return("Add"));
+
     EXPECT_CALL(*context_, task())
             .Times(2)
             .WillRepeatedly(Return(task_));
-    EXPECT_CALL(*context_, finished())
-            .Times(1);
+    EXPECT_CALL(*context_, finished()).Times(1);
 
-    EXPECT_TRUE(std::dynamic_pointer_cast<SubStepLabel>(
-            step.execute(*context_)));
+    EXPECT_TRUE(std::dynamic_pointer_cast<SubStepLabel>(step.execute(*context_)));
+    ASSERT_EQ(task_->labels().size(), 2);
+    EXPECT_EQ(task_->labels()[0], "label_1");
+    EXPECT_EQ(task_->labels()[1], "label_2");
 }

--- a/tests/ui/step/SubStepTest.cpp
+++ b/tests/ui/step/SubStepTest.cpp
@@ -35,31 +35,23 @@ protected:
 TEST_F(SubStepTest, shouldReadTitle) {
     auto step = SubStepTitle(factory_, view_);
 
-    EXPECT_CALL(*view_, ReadTitle(_))
-            .Times(1)
-            .WillOnce(Return("title"));
-    EXPECT_CALL(*context_, wizard_string())
-            .Times(1);
-    EXPECT_CALL(*context_, task())
-            .Times(1)
-            .WillOnce(Return(task_));
-    EXPECT_TRUE(std::dynamic_pointer_cast<SubStepPriority>(
-            step.execute(*context_)));
+    EXPECT_CALL(*context_, wizard_string()).WillOnce(Return("Add"));
+    EXPECT_CALL(*view_, ReadTitle("Add")).WillOnce(Return("title"));
+    EXPECT_CALL(*context_, task()).WillOnce(Return(task_));
+
+    EXPECT_TRUE(std::dynamic_pointer_cast<SubStepPriority>(step.execute(*context_)));
+    EXPECT_EQ(task_->title(), "title");
 }
 
 TEST_F(SubStepTest, shouldReadPriority) {
     auto step = SubStepPriority(factory_, view_);
 
-    EXPECT_CALL(*view_, ReadPriority(_))
-            .Times(1)
-            .WillOnce(Return(Task_Priority_LOW));
-    EXPECT_CALL(*context_, wizard_string())
-            .Times(1);
-    EXPECT_CALL(*context_, task())
-            .Times(1)
-            .WillOnce(Return(task_));
-    EXPECT_TRUE(std::dynamic_pointer_cast<SubStepDate>(
-            step.execute(*context_)));
+    EXPECT_CALL(*context_, wizard_string()).WillOnce(Return("Add"));
+    EXPECT_CALL(*view_, ReadPriority("Add")).WillOnce(Return(Task_Priority_LOW));
+    EXPECT_CALL(*context_, task()).WillOnce(Return(task_));
+
+    EXPECT_TRUE(std::dynamic_pointer_cast<SubStepDate>(step.execute(*context_)));
+    EXPECT_EQ(task_->priority(), Task_Priority_LOW);
 }
 
 TEST_F(SubStepTest, shouldReadDate) {
@@ -69,19 +61,20 @@ TEST_F(SubStepTest, shouldReadDate) {
 
     google::protobuf::Timestamp date;
     date.set_seconds(100);
-
     EXPECT_CALL(*view_, ReadDate("Edit")).WillOnce(Return(date));
+
     EXPECT_CALL(*context_, task()).WillOnce(Return(task_));
 
     EXPECT_TRUE(std::dynamic_pointer_cast<SubStepLabel>(step.execute(*context_)));
+    ASSERT_TRUE(task_->has_date());
+    EXPECT_EQ(task_->date().seconds(), 100);
 }
 
 TEST_F(SubStepTest, shouldReadLabels) {
     auto step = SubStepLabel(factory_, view_);
 
     EXPECT_CALL(*context_, wizard_string()).WillOnce(Return("Add"));
-    EXPECT_CALL(*view_, ReadLabels("Add"))
-            .WillOnce(Return(std::vector<std::string>{"label_1", "label_2"}));
+    EXPECT_CALL(*view_, ReadLabels("Add")).WillOnce(Return(std::vector<std::string>{"label_1", "label_2"}));
 
     EXPECT_CALL(*context_, task())
             .Times(2)

--- a/tests/ui/step/SubStepTest.cpp
+++ b/tests/ui/step/SubStepTest.cpp
@@ -3,7 +3,6 @@
 #include "ui/step/SubSteps.h"
 #include "ui/Factory.h"
 #include "ui/view/ViewMock.h"
-#include "ui/ContextMock.h"
 
 using ::testing::Return;
 
@@ -13,70 +12,62 @@ using namespace ui::step;
 class SubStepTest : public ::testing::Test {
 public:
     void SetUp() override {
-        task_ = std::make_shared<Task>();
         view_ = std::make_shared<ViewMock>(std::make_shared<Reader>(), std::make_shared<Printer>());
         factory_ = std::make_shared<Factory>(view_);
-        context_ = std::make_shared<ContextMock>("");
     }
 
 protected:
-    std::shared_ptr<Task> task_;
     std::shared_ptr<ViewMock> view_;
     std::shared_ptr<Factory> factory_;
-    std::shared_ptr<ContextMock> context_;
 };
 
 TEST_F(SubStepTest, shouldReadTitle) {
-    auto step = SubStepTitle(factory_, view_);
+    SubStepTitle step{factory_, view_};
+    Context context{"Add"};
 
-    EXPECT_CALL(*context_, wizard_string()).WillOnce(Return("Add"));
     EXPECT_CALL(*view_, ReadTitle("Add")).WillOnce(Return("title"));
-    EXPECT_CALL(*context_, task()).WillOnce(Return(task_));
+    EXPECT_TRUE(std::dynamic_pointer_cast<SubStepPriority>(step.execute(context)));
 
-    EXPECT_TRUE(std::dynamic_pointer_cast<SubStepPriority>(step.execute(*context_)));
-    EXPECT_EQ(task_->title(), "title");
+    EXPECT_EQ(context.task()->title(), "title");
+    EXPECT_FALSE(context.if_finished());
 }
 
 TEST_F(SubStepTest, shouldReadPriority) {
-    auto step = SubStepPriority(factory_, view_);
+    SubStepPriority step{factory_, view_};
+    Context context{"Edit"};
 
-    EXPECT_CALL(*context_, wizard_string()).WillOnce(Return("Add"));
-    EXPECT_CALL(*view_, ReadPriority("Add")).WillOnce(Return(Task_Priority_LOW));
-    EXPECT_CALL(*context_, task()).WillOnce(Return(task_));
+    EXPECT_CALL(*view_, ReadPriority("Edit")).WillOnce(Return(Task_Priority_LOW));
+    EXPECT_TRUE(std::dynamic_pointer_cast<SubStepDate>(step.execute(context)));
 
-    EXPECT_TRUE(std::dynamic_pointer_cast<SubStepDate>(step.execute(*context_)));
-    EXPECT_EQ(task_->priority(), Task_Priority_LOW);
+    EXPECT_EQ(context.task()->priority(), Task_Priority_LOW);
+    EXPECT_FALSE(context.if_finished());
 }
 
 TEST_F(SubStepTest, shouldReadDate) {
-    auto step = SubStepDate(factory_, view_);
-
-    EXPECT_CALL(*context_, wizard_string()).WillOnce(Return("Edit"));
+    SubStepDate step{factory_, view_};
+    Context context{"Add"};
 
     google::protobuf::Timestamp date;
     date.set_seconds(100);
-    EXPECT_CALL(*view_, ReadDate("Edit")).WillOnce(Return(date));
 
-    EXPECT_CALL(*context_, task()).WillOnce(Return(task_));
+    EXPECT_CALL(*view_, ReadDate("Add")).WillOnce(Return(date));
+    EXPECT_TRUE(std::dynamic_pointer_cast<SubStepLabel>(step.execute(context)));
 
-    EXPECT_TRUE(std::dynamic_pointer_cast<SubStepLabel>(step.execute(*context_)));
-    ASSERT_TRUE(task_->has_date());
-    EXPECT_EQ(task_->date().seconds(), 100);
+    ASSERT_TRUE(context.task()->has_date());
+    EXPECT_EQ(context.task()->date().seconds(), 100);
+    EXPECT_FALSE(context.if_finished());
 }
 
 TEST_F(SubStepTest, shouldReadLabels) {
-    auto step = SubStepLabel(factory_, view_);
+    SubStepLabel step{factory_, view_};
+    Context context{"Edit"};
 
-    EXPECT_CALL(*context_, wizard_string()).WillOnce(Return("Add"));
-    EXPECT_CALL(*view_, ReadLabels("Add")).WillOnce(Return(std::vector<std::string>{"label_1", "label_2"}));
+    EXPECT_CALL(*view_, ReadLabels("Edit"))
+            .WillOnce(Return(std::vector<std::string>{"label_1", "label_2"}));
+    EXPECT_TRUE(std::dynamic_pointer_cast<SubStepLabel>(step.execute(context)));
 
-    EXPECT_CALL(*context_, task())
-            .Times(2)
-            .WillRepeatedly(Return(task_));
-    EXPECT_CALL(*context_, finished()).Times(1);
-
-    EXPECT_TRUE(std::dynamic_pointer_cast<SubStepLabel>(step.execute(*context_)));
-    ASSERT_EQ(task_->labels().size(), 2);
-    EXPECT_EQ(task_->labels()[0], "label_1");
-    EXPECT_EQ(task_->labels()[1], "label_2");
+    ASSERT_EQ(context.task()->labels().size(), 2);
+    EXPECT_EQ(context.task()->labels()[0], "label_1");
+    EXPECT_EQ(context.task()->labels()[1], "label_2");
+    EXPECT_TRUE(context.if_finished());
 }


### PR DESCRIPTION
- ContextMock is no longer used
- Сode formatted, unnecessary code removed
- Added additional checks in EXPECT_CALLs conditions